### PR TITLE
Bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Contributions are welcome - fork, fix and send pull requests against the `develo
 
 ## Changelog
 
+### 1.5.1
+* Bugfix: fixed issue where an array did not need to be passed through the function filtering active plugins.
+
 ### 1.5.0
 * Enhancement:  added option to prevent browser disclosure.
 * Enhancement:  added option to prevent location info being sent to wordpress.org.

--- a/classes/privacy.php
+++ b/classes/privacy.php
@@ -251,7 +251,10 @@ class Privacy_My_Way {
 						$plugins = array();
 						break;
 					case 'active':
-						$plugins = $this->plugins_option_active( $plugins );
+						// If the index does not exist, then the array is already the active plugins
+						if ( isset( $plugins['plugins'] ) ) {
+							$plugins = $this->plugins_option_active( $plugins );
+						}
 						break;
 					case 'filter':
 						$plugins = $this->plugins_option_filter( $plugins );

--- a/readme.txt
+++ b/readme.txt
@@ -47,6 +47,9 @@ See the [GitHib Wiki](https://github.com/RichardCoffee/privacy-my-way/wiki).  Op
 
 == Changelog ==
 
+= 1.5.1 =
+* Bugfix: fixed issue where an array did not need to be passed through the function filtering active plugins.
+
 = 1.5.0 =
 * Enhancement:  added option to prevent browser disclosure.
 * Enhancement:  added option to prevent location info being sent to wordpress.org.

--- a/version.txt
+++ b/version.txt
@@ -1,0 +1,1 @@
+Last updated on: 20180830


### PR DESCRIPTION
Fixed issue where an array did not need to be passed through the function filtering active plugins.  This occurred when only the active plugins list was be sent to wordpress.